### PR TITLE
Fixes #45: Hotfix for HAR files not loading in Chrome

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -547,6 +547,11 @@ export async function startAnalysis<
         return {
             log: {
                 ...har.log,
+
+                // Hotfix for HAR files not loading in Chrome (see #45).
+                // TODO: This should be removed once we upgrade mitmproxy or switch away from it (#46).
+                pages: [],
+
                 creator: {
                     name: 'cyanoacrylate',
                     version: cyanoacrylateVersion,


### PR DESCRIPTION
This is based on #39, which needs to be merged first.