### PR TITLE
Fixes #50: Print version to file and export it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ tmp.*
 *.tmp.*
 
 dist/
+.yalc/
+yalc.lock
 
 # Created by https://www.toptal.com/developers/gitignore/api/linux,macos,windows,visualstudiocode,jetbrains+all,sublimetext,node,python
 # Edit at https://www.toptal.com/developers/gitignore?templates=linux,macos,windows,visualstudiocode,jetbrains+all,sublimetext,node,python

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ Functions that can be used to instrument the device and analyze apps.
 
 #### Defined in
 
-[src/index.ts:104](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L104)
+[src/index.ts:103](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L103)
 
 ___
 
@@ -93,7 +93,7 @@ The options for the `startAnalysis()` function.
 
 #### Defined in
 
-[src/index.ts:328](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L328)
+[src/index.ts:327](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L327)
 
 ___
 
@@ -129,7 +129,7 @@ Metadata about an app, as returned by parseAppMeta.
 
 #### Defined in
 
-node_modules/appstraction/dist/index.d.ts:85
+node_modules/appstraction/dist/index.d.ts:86
 
 ___
 
@@ -163,7 +163,7 @@ Functions that can be used to control an app analysis.
 
 #### Defined in
 
-[src/index.ts:177](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L177)
+[src/index.ts:176](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L176)
 
 ___
 
@@ -183,7 +183,7 @@ The result of an app analysis.
 
 #### Defined in
 
-[src/index.ts:264](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L264)
+[src/index.ts:263](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L263)
 
 ___
 
@@ -201,7 +201,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-node_modules/appstraction/dist/index.d.ts:467
+node_modules/appstraction/dist/index.d.ts:468
 
 ___
 
@@ -226,7 +226,7 @@ Metadata about the device the analysis was run on.
 
 #### Defined in
 
-[src/index.ts:41](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L41)
+[src/index.ts:40](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L40)
 
 ___
 
@@ -245,7 +245,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-node_modules/appstraction/dist/index.d.ts:469
+node_modules/appstraction/dist/index.d.ts:470
 
 ___
 
@@ -481,7 +481,7 @@ Functions that are available for the platforms.
 
 #### Defined in
 
-node_modules/appstraction/dist/index.d.ts:116
+node_modules/appstraction/dist/index.d.ts:117
 
 ___
 
@@ -515,7 +515,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[src/index.ts:282](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L282)
+[src/index.ts:281](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L281)
 
 ___
 
@@ -533,7 +533,7 @@ A capability supported by this library.
 
 #### Defined in
 
-[src/index.ts:34](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L34)
+[src/index.ts:33](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L33)
 
 ___
 
@@ -545,7 +545,7 @@ A platform that is supported by this library.
 
 #### Defined in
 
-node_modules/appstraction/dist/index.d.ts:64
+node_modules/appstraction/dist/index.d.ts:65
 
 ___
 
@@ -563,7 +563,7 @@ A run target that is supported by this library for the given platform.
 
 #### Defined in
 
-node_modules/appstraction/dist/index.d.ts:66
+node_modules/appstraction/dist/index.d.ts:67
 
 ___
 
@@ -579,7 +579,7 @@ Options for a traffic collection that specifies which apps to collect traffic fr
 
 #### Defined in
 
-[src/index.ts:101](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L101)
+[src/index.ts:100](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L100)
 
 ___
 
@@ -592,7 +592,7 @@ through.
 
 #### Defined in
 
-[src/index.ts:63](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L63)
+[src/index.ts:62](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L62)
 
 ___
 
@@ -616,7 +616,7 @@ Metadata about the traffic collection as included in a [TweaselHar](README.md#tw
 
 #### Defined in
 
-[src/index.ts:70](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L70)
+[src/index.ts:69](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L69)
 
 ## Variables
 
@@ -695,4 +695,4 @@ An object that can be used to instrument the device and analyze apps.
 
 #### Defined in
 
-[src/index.ts:362](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L362)
+[src/index.ts:361](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L361)

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
         "/src/ipcEventsAddon.py"
     ],
     "scripts": {
-        "build": "parcel build",
+        "build": "yarn print-version && parcel build",
         "fix": "yarn eslint . --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx --fix",
         "postinstall": "node scripts/postinstall.js",
         "lint": "tsc && eslint . --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx && git diff --check",
-        "prepack": "rm -rf dist && yarn build && yarn typedoc",
+        "prepack": "rm -rf dist && yarn build && yarn typedoc && git add src/version.gen.ts",
+        "print-version": "echo \"// Shim to make the version available at runtime. Auto-generated, please ignore.\nexport const cyanoacrylateVersion = '$npm_package_version';\" > src/version.gen.ts",
         "test": "echo 'TODO: No tests specified yet.'",
         "watch": "parcel watch"
     },
@@ -56,7 +57,7 @@
     "dependencies": {
         "@types/har-format": "^1.2.10",
         "andromatic": "^1.1.1",
-        "appstraction": "^1.3.0",
+        "appstraction": "1.3.1",
         "autopy": "^1.1.1",
         "cross-fetch": "^3.1.5",
         "ctrlc-windows": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,10 @@
         "fix": "yarn eslint . --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx --fix",
         "postinstall": "node scripts/postinstall.js",
         "lint": "tsc && eslint . --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx && git diff --check",
-        "prepack": "rm -rf dist && yarn build && yarn typedoc && git add src/version.gen.ts",
+        "prepack": "rm -rf dist && yarn build && yarn typedoc",
         "print-version": "echo \"// Shim to make the version available at runtime. Auto-generated, please ignore.\nexport const cyanoacrylateVersion = '$npm_package_version';\" > src/version.gen.ts",
         "test": "echo 'TODO: No tests specified yet.'",
+        "postversion": "yarn print-version && git add src/version.gen.ts",
         "watch": "parcel watch"
     },
     "husky": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,7 @@ import type {
     SupportedPlatform,
     SupportedRunTarget,
 } from 'appstraction';
-import { parseAppMeta, platformApi } from 'appstraction';
-import { version as appstractionVersion } from 'appstraction/package.json';
+import { appstractionVersion, parseAppMeta, platformApi } from 'appstraction';
 import type { ExecaChildProcess } from 'execa';
 import { readFile } from 'fs/promises';
 import type { Har } from 'har-format';
@@ -17,7 +16,6 @@ import timeout, { TimeoutError } from 'p-timeout';
 import { join } from 'path';
 import process from 'process';
 import { temporaryFile } from 'tempy';
-import { version as cyanoacrylateVersion } from '../package.json';
 import { ensurePythonDependencies } from '../scripts/common/python';
 import type { MitmproxyEvent } from './util';
 import {
@@ -29,6 +27,7 @@ import {
     onMitmproxyEvent,
     startEmulator,
 } from './util';
+import { cyanoacrylateVersion } from './version.gen';
 
 /** A capability supported by this library. */
 export type SupportedCapability<Platform extends SupportedPlatform> = Platform extends 'android'
@@ -753,4 +752,5 @@ export type {
     MitmproxyServerSpec,
     MitmproxyTlsData,
 } from './util';
+export { cyanoacrylateVersion } from './version.gen';
 export type { App };

--- a/src/version.gen.ts
+++ b/src/version.gen.ts
@@ -1,2 +1,2 @@
 // Shim to make the version available at runtime. Auto-generated, please ignore.
-export const cyanoacrylateVersion = '1.1.0';
+export const cyanoacrylateVersion = '1.2.0';

--- a/src/version.gen.ts
+++ b/src/version.gen.ts
@@ -1,0 +1,2 @@
+// Shim to make the version available at runtime. Auto-generated, please ignore.
+export const cyanoacrylateVersion = '1.1.0';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,10 +1585,10 @@ ap@~0.2.0:
   resolved "https://registry.yarnpkg.com/ap/-/ap-0.2.0.tgz#ae0942600b29912f0d2b14ec60c45e8f330b6110"
   integrity sha512-ImdvquIuBSVpWRWhB441UjvTcZqic1RL+lTQaUKGdGEp1aiTvt/phAvY8Vvs32qya5FJBI8U+tzNBYzFDQY/lQ==
 
-appstraction@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/appstraction/-/appstraction-1.3.0.tgz#f448e580f8707bb19db53ec84b3291fe0a982bb0"
-  integrity sha512-BU17Kqtoz5jcZaPMEmQdgk/UlzO82Qfi8UomxF9SXNgrJZk77guohuzT7YxsfmNDipbj/E6GS1TPkgtwD0b8lg==
+appstraction@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/appstraction/-/appstraction-1.3.1.tgz#05208c5797add78e4a3eda52b2fe9b19f40f64de"
+  integrity sha512-yaevXwhVbyCnHwZs5CZXXUvT+SKR+bJrzvBPdRQgjbhUkcbJmTC0nRc9LyXvw23M+cZUROv/yxHP4K3r9WLoRA==
   dependencies:
     "@napi-rs/lzma" "^1.1.2"
     andromatic "^1.1.1"


### PR DESCRIPTION
We now print the version to a file, like it was implemented in tweaselORG/appstraction#136.

I tested that this fixes https://github.com/tweaselORG/cli/issues/39.