### PR TITLE
WIP: Manage Emulators automatically

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ cyanoacrylate
 - [MitmproxyTlsData](README.md#mitmproxytlsdata)
 - [PlatformApi](README.md#platformapi)
 - [RunTargetOptions](README.md#runtargetoptions)
+- [StartEmulatorOptions](README.md#startemulatoroptions)
 - [SupportedCapability](README.md#supportedcapability)
 - [SupportedPlatform](README.md#supportedplatform)
 - [SupportedRunTarget](README.md#supportedruntarget)
@@ -73,7 +74,7 @@ Functions that can be used to instrument the device and analyze apps.
 
 #### Defined in
 
-[src/index.ts:103](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L103)
+[src/index.ts:106](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L106)
 
 ___
 
@@ -93,7 +94,7 @@ The options for the `startAnalysis()` function.
 
 #### Defined in
 
-[src/index.ts:343](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L343)
+[src/index.ts:349](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L349)
 
 ___
 
@@ -163,7 +164,7 @@ Functions that can be used to control an app analysis.
 
 #### Defined in
 
-[src/index.ts:176](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L176)
+[src/index.ts:179](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L179)
 
 ___
 
@@ -183,7 +184,7 @@ The result of an app analysis.
 
 #### Defined in
 
-[src/index.ts:263](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L263)
+[src/index.ts:266](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L266)
 
 ___
 
@@ -201,7 +202,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-node_modules/appstraction/dist/index.d.ts:468
+node_modules/appstraction/dist/index.d.ts:474
 
 ___
 
@@ -226,7 +227,7 @@ Metadata about the device the analysis was run on.
 
 #### Defined in
 
-[src/index.ts:40](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L40)
+[src/index.ts:43](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L43)
 
 ___
 
@@ -245,7 +246,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-node_modules/appstraction/dist/index.d.ts:470
+node_modules/appstraction/dist/index.d.ts:476
 
 ___
 
@@ -287,7 +288,7 @@ https://docs.mitmproxy.org/stable/api/mitmproxy/certs.html#Cert
 
 #### Defined in
 
-[src/util.ts:15](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L15)
+[src/util.ts:16](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L16)
 
 ___
 
@@ -303,7 +304,7 @@ https://docs.mitmproxy.org/stable/api/mitmproxy/connection.html#Client
 
 #### Defined in
 
-[src/util.ts:146](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L146)
+[src/util.ts:147](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L147)
 
 ___
 
@@ -341,7 +342,7 @@ https://docs.mitmproxy.org/stable/api/mitmproxy/connection.html#Connection
 
 #### Defined in
 
-[src/util.ts:75](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L75)
+[src/util.ts:76](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L76)
 
 ___
 
@@ -353,7 +354,7 @@ The events sent by the mitmproxy IPC events addon.
 
 #### Defined in
 
-[src/util.ts:186](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L186)
+[src/util.ts:187](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L187)
 
 ___
 
@@ -369,7 +370,7 @@ https://docs.mitmproxy.org/stable/api/mitmproxy/connection.html#Server
 
 #### Defined in
 
-[src/util.ts:161](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L161)
+[src/util.ts:162](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L162)
 
 ___
 
@@ -403,7 +404,7 @@ https://github.com/mitmproxy/mitmproxy/blob/8f1329377147538afdf06344179c2fd90795
 
 #### Defined in
 
-[src/util.ts:175](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L175)
+[src/util.ts:176](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L176)
 
 ___
 
@@ -429,7 +430,7 @@ https://docs.mitmproxy.org/stable/api/mitmproxy/tls.html#TlsData
 
 #### Defined in
 
-[src/util.ts:127](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L127)
+[src/util.ts:128](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/util.ts#L128)
 
 ___
 
@@ -471,6 +472,7 @@ Functions that are available for the platforms.
 | `setClipboard` | (`text`: `string`) => `Promise`<`void`\> | Set the clipboard to the given text. Requires the `frida` capability on Android and iOS. |
 | `setDeviceName` | (`deviceName`: `string`) => `Promise`<`void`\> | Sets the name of the device, which shows up to other network or bluetooth devices. |
 | `setProxy` | `Platform` extends ``"android"`` ? (`proxy`: ``"wireguard"`` extends `Capability` ? `WireGuardConfig` : `Proxy` \| ``null``) => `Promise`<`void`\> : `Platform` extends ``"ios"`` ? (`proxy`: `Proxy` \| ``null``) => `Promise`<`void`\> : `never` | Set or disable the proxy on the device. If you have enabled the `wireguard` capability, this will start or stop a WireGuard tunnel. Otherwise, it will set the global proxy on the device. On iOS, the proxy is set for the current WiFi network. It won't apply for other networks or for cellular data connections. WireGuard is currently only supported on Android. Enabling a WireGuard tunnel requires the `root` capability. **`Remarks`** The WireGuard integration will create a new tunnel in the app called `appstraction` and delete it when the proxy is stopped. If you have an existing tunnel with the same name, it will be overridden. **`Param`** The proxy to set, or `null` to disable the proxy. If you have enabled the `wireguard` capability, this is a string of the full WireGuard configuration to use. |
+| `snapshotDeviceState` | `Platform` extends ``"android"`` ? `RunTarget` extends ``"emulator"`` ? (`snapshotName`: `string`) => `Promise`<`void`\> : `never` : `never` | Save the device state to the specified snapshot (only available for emulators). **`Param`** The name of the snapshot to save to. |
 | `startApp` | (`appId`: `string`) => `Promise`<`void`\> | Start the app with the given app ID. Doesn't wait for the app to be ready. Also enables the certificate pinning bypass if enabled. Requires the `frida` or `ssh` capability on iOS. On Android, this will start the app with or without a certificate pinning bypass depending on the `certificate-pinning-bypass` capability. |
 | `stopApp` | (`appId`: `string`) => `Promise`<`void`\> | Force-stop the app with the given app ID. |
 | `target` | { `platform`: `Platform` ; `runTarget`: `RunTarget`  } | An indicator for what platform and run target this instance of PlatformApi is configured for. This is useful mostly to write typeguards. |
@@ -495,18 +497,11 @@ The options for a specific platform/run target combination.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `android` | { `device`: `unknown` ; `emulator`: { `snapshotName?`: `string` ; `startEmulatorOptions?`: { `audio?`: `boolean` ; `emulatorName?`: `string` ; `ephemeral?`: `boolean` ; `hardwareAcceleration?`: { `gpuMode?`: ``"auto"`` \| ``"host"`` \| ``"swiftshader_indirect"`` \| ``"angle_indirect"`` \| ``"guest"`` ; `mode?`: ``"auto"`` \| ``"off"`` \| ``"on"``  } ; `headless?`: `boolean`  }  }  } | The options for the Android platform. |
+| `android` | { `device`: `unknown` ; `emulator`: { `snapshotName?`: `string` ; `startEmulatorOptions?`: [`StartEmulatorOptions`](README.md#startemulatoroptions)  }  } | The options for the Android platform. |
 | `android.device` | `unknown` | The options for the Android physical device run target. |
-| `android.emulator` | { `snapshotName?`: `string` ; `startEmulatorOptions?`: { `audio?`: `boolean` ; `emulatorName?`: `string` ; `ephemeral?`: `boolean` ; `hardwareAcceleration?`: { `gpuMode?`: ``"auto"`` \| ``"host"`` \| ``"swiftshader_indirect"`` \| ``"angle_indirect"`` \| ``"guest"`` ; `mode?`: ``"auto"`` \| ``"off"`` \| ``"on"``  } ; `headless?`: `boolean`  }  } | The options for the Android emulator run target. |
+| `android.emulator` | { `snapshotName?`: `string` ; `startEmulatorOptions?`: [`StartEmulatorOptions`](README.md#startemulatoroptions)  } | The options for the Android emulator run target. |
 | `android.emulator.snapshotName?` | `string` | The name of a snapshot to use when resetting the emulator. |
-| `android.emulator.startEmulatorOptions?` | { `audio?`: `boolean` ; `emulatorName?`: `string` ; `ephemeral?`: `boolean` ; `hardwareAcceleration?`: { `gpuMode?`: ``"auto"`` \| ``"host"`` \| ``"swiftshader_indirect"`` \| ``"angle_indirect"`` \| ``"guest"`` ; `mode?`: ``"auto"`` \| ``"off"`` \| ``"on"``  } ; `headless?`: `boolean`  } | Options for the emulator if you want it to be automatically started and stopped by this library. |
-| `android.emulator.startEmulatorOptions.audio?` | `boolean` | Whether to start the emulator with audio (default: `false`). |
-| `android.emulator.startEmulatorOptions.emulatorName?` | `string` | The name of the emulator to start. |
-| `android.emulator.startEmulatorOptions.ephemeral?` | `boolean` | Whether to discard all changes when exiting the emulator (default: `true`). |
-| `android.emulator.startEmulatorOptions.hardwareAcceleration?` | { `gpuMode?`: ``"auto"`` \| ``"host"`` \| ``"swiftshader_indirect"`` \| ``"angle_indirect"`` \| ``"guest"`` ; `mode?`: ``"auto"`` \| ``"off"`` \| ``"on"``  } | Options for hardware accelerations. These do not need to be set if everything works with the defaults. |
-| `android.emulator.startEmulatorOptions.hardwareAcceleration.gpuMode?` | ``"auto"`` \| ``"host"`` \| ``"swiftshader_indirect"`` \| ``"angle_indirect"`` \| ``"guest"`` | Sets the `-gpu` option, see https://developer.android.com/studio/run/emulator-acceleration#accel-graphics. |
-| `android.emulator.startEmulatorOptions.hardwareAcceleration.mode?` | ``"auto"`` \| ``"off"`` \| ``"on"`` | Sets the `-accel` option, see https://developer.android.com/studio/run/emulator-commandline#common. |
-| `android.emulator.startEmulatorOptions.headless?` | `boolean` | Whether to start the emulator in headless mode (default: `false`). |
+| `android.emulator.startEmulatorOptions?` | [`StartEmulatorOptions`](README.md#startemulatoroptions) | Options for the emulator if you want it to be automatically managed by this library. |
 | `ios` | { `device`: { `ip?`: `string` ; `password?`: `string` ; `port?`: `number` ; `proxyIp`: `string` ; `username?`: ``"mobile"`` \| ``"root"``  } ; `emulator`: `never`  } | The options for the iOS platform. |
 | `ios.device` | { `ip?`: `string` ; `password?`: `string` ; `port?`: `number` ; `proxyIp`: `string` ; `username?`: ``"mobile"`` \| ``"root"``  } | The options for the iOS physical device run target. |
 | `ios.device.ip?` | `string` | The device's IP address. If none is given, a connection via USB port forwarding is attempted. |
@@ -518,7 +513,19 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[src/index.ts:281](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L281)
+[src/index.ts:312](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L312)
+
+___
+
+### StartEmulatorOptions
+
+Ƭ **StartEmulatorOptions**: { `createEmulator?`: `undefined` ; `emulatorName?`: `string`  } \| { `createEmulator`: `EmulatorOptions`  } & { `audio?`: `boolean` ; `ephemeral?`: `boolean` ; `hardwareAcceleration?`: { `gpuMode?`: ``"auto"`` \| ``"host"`` \| ``"swiftshader_indirect"`` \| ``"angle_indirect"`` \| ``"guest"`` ; `mode?`: ``"auto"`` \| ``"off"`` \| ``"on"``  } ; `headless?`: `boolean`  }
+
+Options for the emulator if you want it to be automatically managed by this library.
+
+#### Defined in
+
+[src/index.ts:283](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L283)
 
 ___
 
@@ -536,7 +543,7 @@ A capability supported by this library.
 
 #### Defined in
 
-[src/index.ts:33](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L33)
+[src/index.ts:36](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L36)
 
 ___
 
@@ -582,7 +589,7 @@ Options for a traffic collection that specifies which apps to collect traffic fr
 
 #### Defined in
 
-[src/index.ts:100](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L100)
+[src/index.ts:103](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L103)
 
 ___
 
@@ -595,7 +602,7 @@ through.
 
 #### Defined in
 
-[src/index.ts:62](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L62)
+[src/index.ts:65](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L65)
 
 ___
 
@@ -619,7 +626,7 @@ Metadata about the traffic collection as included in a [TweaselHar](README.md#tw
 
 #### Defined in
 
-[src/index.ts:69](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L69)
+[src/index.ts:72](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L72)
 
 ## Variables
 
@@ -698,4 +705,4 @@ An object that can be used to instrument the device and analyze apps.
 
 #### Defined in
 
-[src/index.ts:377](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L377)
+[src/index.ts:392](https://github.com/tweaselORG/cyanoacrylate/blob/main/src/index.ts#L392)

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dependencies": {
         "@types/har-format": "^1.2.10",
         "andromatic": "^1.1.1",
-        "appstraction": "1.3.1",
+        "appstraction": "file:.yalc/appstraction",
         "autopy": "^1.1.1",
         "cross-fetch": "^3.1.5",
         "ctrlc-windows": "^2.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import type { EmulatorOptions } from 'andromatic';
 import type {
     AppMeta as App,
     AppPath,
@@ -21,11 +22,13 @@ import type { MitmproxyEvent } from './util';
 import {
     awaitMitmproxyEvent,
     awaitProcessClose,
+    deleteEmulator,
     dnsLookup,
     fileExists,
     killProcess,
     onMitmproxyEvent,
-    startEmulator,
+    restartEmulator,
+    startNewEmulator,
 } from './util';
 import { cyanoacrylateVersion } from './version.gen';
 
@@ -276,6 +279,34 @@ export type AppAnalysisResult = {
     mitmproxyEvents: MitmproxyEvent[];
 };
 
+/** Options for the emulator if you want it to be automatically managed by this library. */
+export type StartEmulatorOptions = (
+    | {
+          /** The name of the emulator to start. */
+          emulatorName?: string;
+          /** If set, creates an emulator specific for the analysis. */
+          createEmulator?: undefined;
+      }
+    | {
+          /** If set, creates an emulator specific for the analysis. */
+          createEmulator: EmulatorOptions;
+      }
+) & {
+    /** Whether to start the emulator in headless mode (default: `false`). */
+    headless?: boolean;
+    /** Whether to start the emulator with audio (default: `false`). */
+    audio?: boolean;
+    /** Whether to discard all changes when exiting the emulator (default: `true`). */
+    ephemeral?: boolean;
+    /** Options for hardware accelerations. These do not need to be set if everything works with the defaults. */
+    hardwareAcceleration?: {
+        /** Sets the `-accel` option, see https://developer.android.com/studio/run/emulator-commandline#common. */
+        mode?: 'auto' | 'off' | 'on';
+        /** Sets the `-gpu` option, see https://developer.android.com/studio/run/emulator-acceleration#accel-graphics. */
+        gpuMode?: 'auto' | 'host' | 'swiftshader_indirect' | 'angle_indirect' | 'guest';
+    };
+};
+
 /** The options for a specific platform/run target combination. */
 // Use `unknown` here to mean "no options", and `never` to mean "not supported".
 export type RunTargetOptions = {
@@ -283,35 +314,10 @@ export type RunTargetOptions = {
     android: {
         /** The options for the Android emulator run target. */
         emulator: {
-            /** Options for the emulator if you want it to be automatically started and stopped by this library. */
-            startEmulatorOptions?: {
-                /** The name of the emulator to start. */
-                emulatorName?: string;
-                /** Whether to start the emulator in headless mode (default: `false`). */
-                headless?: boolean;
-                /** Whether to start the emulator with audio (default: `false`). */
-                audio?: boolean;
-                /** Whether to discard all changes when exiting the emulator (default: `true`). */
-                ephemeral?: boolean;
-                /**
-                 * Options for hardware accelerations. These do not need to be set if everything works with the
-                 * defaults.
-                 */
-                hardwareAcceleration?: {
-                    /**
-                     * Sets the `-accel` option, see
-                     * https://developer.android.com/studio/run/emulator-commandline#common.
-                     */
-                    mode?: 'auto' | 'off' | 'on';
-                    /**
-                     * Sets the `-gpu` option, see
-                     * https://developer.android.com/studio/run/emulator-acceleration#accel-graphics.
-                     */
-                    gpuMode?: 'auto' | 'host' | 'swiftshader_indirect' | 'angle_indirect' | 'guest';
-                };
-            };
             /** The name of a snapshot to use when resetting the emulator. */
             snapshotName?: string;
+            /** Options for the emulator if you want it to be automatically managed by this library. */
+            startEmulatorOptions?: StartEmulatorOptions;
         };
         /** The options for the Android physical device run target. */
         device: unknown;
@@ -366,6 +372,15 @@ export type AnalysisOptions<
           targetOptions?: Record<string, never>;
       });
 
+export type EmulatorState = {
+    proc: ExecaChildProcess<string>;
+    emulatorName: string;
+    startArgs: string[];
+    resetSnapshotName: string | undefined;
+    failedStarts: number;
+    createdByLib: boolean;
+};
+
 /**
  * Initialize an analysis for the given platform and run target. Remember to call `stop()` on the returned object when
  * you want to end the analysis.
@@ -409,7 +424,7 @@ export async function startAnalysis<
         ),
     };
 
-    let emulatorProcess: ExecaChildProcess | undefined;
+    let emulator: EmulatorState | undefined;
     let trafficCollectionInProgress: { startDate: Date; options: TrafficCollectionOptions } | false = false;
     let mitmproxyState:
         | { proc: ExecaChildProcess; harOutputPath: string; wireguardConf?: string | null; events: MitmproxyEvent[] }
@@ -587,39 +602,53 @@ export async function startAnalysis<
         platform,
 
         ensureDevice: async (ensureOptions) => {
-            if (ensureOptions?.killExisting) await killProcess(emulatorProcess);
+            if (ensureOptions?.killExisting) await killProcess(emulator?.proc);
 
             // Start the emulator if necessary and a name was provided.
-            if (
-                (!emulatorProcess || emulatorProcess.exitCode !== null) &&
-                analysisOptions.platform === 'android' &&
-                analysisOptions.runTarget === 'emulator'
-            ) {
+            if (analysisOptions.platform === 'android' && analysisOptions.runTarget === 'emulator') {
                 const targetOptions = analysisOptions.targetOptions as
                     | RunTargetOptions['android']['emulator']
                     | undefined;
-                const emulatorName = targetOptions?.startEmulatorOptions?.emulatorName;
-                if (emulatorName) {
-                    const cmdArgs = ['-no-boot-anim'];
-                    if (targetOptions?.startEmulatorOptions?.headless === true) cmdArgs.push('-no-window');
-                    if (targetOptions?.startEmulatorOptions?.audio !== true) cmdArgs.push('-no-audio');
-                    if (targetOptions?.startEmulatorOptions?.ephemeral !== false) cmdArgs.push('-no-snapshot-save');
-                    if (targetOptions?.startEmulatorOptions?.hardwareAcceleration?.mode)
-                        cmdArgs.push('-accel', targetOptions?.startEmulatorOptions?.hardwareAcceleration?.mode);
-                    if (targetOptions?.startEmulatorOptions?.hardwareAcceleration?.gpuMode)
-                        cmdArgs.push('-gpu', targetOptions?.startEmulatorOptions?.hardwareAcceleration?.gpuMode);
+
+                // ESLint wrongly thinks an optional chain would be logically equivalent
+                // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+                if (emulator && emulator.proc.exitCode !== null) restartEmulator(emulator);
+                else if (!emulator) {
+                    if (
+                        targetOptions?.startEmulatorOptions?.createEmulator !== undefined ||
+                        targetOptions?.startEmulatorOptions?.emulatorName
+                    ) {
+                        // Create or start a new emulator
+                        // eslint-disable-next-line require-atomic-updates
+                        emulator = await startNewEmulator(targetOptions?.startEmulatorOptions);
+                        emulator.proc.catch((error) => {
+                            // We need to rethrow the error in this context to halt execution.
+                            throw new Error(`Emulator failed to start: ${error.message}`);
+                        });
+                        emulator.resetSnapshotName =
+                            targetOptions?.startEmulatorOptions?.createEmulator !== undefined
+                                ? targetOptions.snapshotName
+                                : undefined;
+                    }
+                }
+
+                await platform.waitForDevice(150);
+
+                await platform.ensureDevice();
+
+                if (emulator?.createdByLib && !emulator?.resetSnapshotName) {
+                    // The emulator is managed by us, so let’s take a snapshot after we ensured for the first time.
+                    const snapshotName = `ca-ensured-${Date.now()}`;
+                    await (platform as unknown as PlatformApi<'android', 'emulator', [], []>).snapshotDeviceState(
+                        snapshotName
+                    );
 
                     // eslint-disable-next-line require-atomic-updates
-                    emulatorProcess = (await startEmulator(emulatorName, cmdArgs))();
-                    emulatorProcess.catch((error) => {
-                        // We need to rethrow the error in this context to halt execution.
-                        throw new Error(`Emulator failed to start: ${error.message}`);
-                    });
-                    await platform.waitForDevice(150);
+                    emulator.resetSnapshotName = snapshotName;
                 }
+            } else {
+                await platform.ensureDevice();
             }
-
-            await platform.ensureDevice();
 
             device = {
                 platform: analysisOptions.platform,
@@ -651,8 +680,7 @@ export async function startAnalysis<
             if (analysisOptions.platform !== 'android' || analysisOptions.runTarget !== 'emulator')
                 throw new Error('Resetting devices is only supported for Android emulators.');
 
-            const snapshotName = (analysisOptions.targetOptions as RunTargetOptions['android']['emulator'])
-                ?.snapshotName;
+            const snapshotName = emulator?.resetSnapshotName;
             if (!snapshotName) throw new Error('Cannot reset device: No snapshot name specified.');
 
             return timeout(platform.resetDevice(snapshotName), {
@@ -751,8 +779,11 @@ export async function startAnalysis<
         stop: async () => {
             await killProcess(mitmproxyState?.proc);
 
-            if (analysisOptions.platform === 'android' && analysisOptions.runTarget === 'emulator')
-                await killProcess(emulatorProcess);
+            if (analysisOptions.platform === 'android' && analysisOptions.runTarget === 'emulator') {
+                // Clean up the emulator
+                await killProcess(emulator?.proc);
+                if (emulator?.createdByLib) await deleteEmulator(emulator);
+            }
         },
     };
 }


### PR DESCRIPTION
We want to manage emulators automatically, create and delete them as needed and recover failure states (in doubt by creating new emulators on the fly). This is a first draft.

Depends on https://github.com/tweaselORG/appstraction/pull/137 to be released to merge.